### PR TITLE
Fix RSS feed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@ SHELL := env PATH=$(PATH) /bin/sh
 
 PORT  ?= 4000
 
-dev: bun.lockb ## Run a local dev server
+dev: bun.lock ## Run a local dev server
 	@PORT=$(PORT) next dev --turbo
 .PHONY: dev
 
-build: bun.lockb ## Build site for production
+build: bun.lock ## Build site for production
 	@next build
 .PHONY: build
 
-lint: bun.lockb ## Lint files for code quality
+lint: bun.lock ## Lint files for code quality
 	@next lint
 .PHONY: lint
 
-format: bun.lockb ## Format code to a standard style
+format: bun.lock ## Format code to a standard style
 	@eslint --fix 'src/**/*.{js,jsx,ts,tsx}'
 	@prettier --write 'src/**/*.{js,jsx,ts,tsx}'
 .PHONY: format
@@ -26,10 +26,10 @@ clean: ## Clear all caches
 	@trash ./.content-collections
 .PHONY: clean
 
-.next: bun.lockb next.config.js $(shell fd -g '**/*.{ts,tsx,css}' .) public
+.next: bun.lock next.config.js $(shell fd -g '**/*.{ts,tsx,css}' .) public
 	@next build
 
-bun.lockb: node_modules package.json
+bun.lock: node_modules package.json
 	@bun install --frozen-lockfile
 	@touch -mr $(shell ls -Atd $? | head -1) $@
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ import { withContentCollections } from "@content-collections/next"
 import { withPlausibleProxy } from "next-plausible"
 
 const config: NextConfig = {
-  reactStrictMode: true,
   poweredByHeader: false,
   images: {
     formats: ["image/avif", "image/webp"],
@@ -24,13 +23,8 @@ const config: NextConfig = {
       },
     ]
   },
-  async rewrites() {
-    return [
-      { source: "/index.xml", destination: "/api/rss" },
-      { source: "/log/index.xml", destination: "/api/rss" },
-    ]
-  },
 }
+
 
 export default withPlausibleProxy({
   scriptName: "metrics",

--- a/src/app/index.xml/route.ts
+++ b/src/app/index.xml/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../api/rss/route"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,9 +11,10 @@ type Props = {
 export default function RootLayout({ children }: Props) {
   return (
     <html lang="en">
-      <PlausibleProvider domain="rosszurowski.com" />
       <body>
+      <PlausibleProvider domain="rosszurowski.com">
         <Providers>{children}</Providers>
+        </PlausibleProvider>
       </body>
     </html>
   )

--- a/src/app/log/index.xml/route.ts
+++ b/src/app/log/index.xml/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../../api/rss/route"


### PR DESCRIPTION
It looks like a recent update to `next-plausible` broke the proxying that the RSS feed relied on. This commit fixes that.